### PR TITLE
Fix delete key handling

### DIFF
--- a/guru-mode.el
+++ b/guru-mode.el
@@ -49,7 +49,7 @@
     ("<C-down>" "M-}" forward-paragraph)
     ("<M-left>" "M-b" left-word)
     ("<M-right>" "M-f" right-word)
-    ("<delete>" "C-d" delete-char)
+    ("<deletechar>" "C-d" delete-forward-char)
     ("<C-delete>" "M-d" kill-word)
     ("<next>" "C-v" scroll-up-command)
     ("<C-next>" "M-x <" scroll-left)


### PR DESCRIPTION
Keybinding `<delete>` results in error as specified in [this issue](https://github.com/bbatsov/prelude/issues/881) when running Emacs in GUI mode, and it's getting ingored when running on console. 

Imo original command for `DEL`  should be `delete-forward-char` as specified [here](http://www.gnu.org/software/emacs/manual/html_node/emacs/Deletion.html). 